### PR TITLE
Not ignoring first line of stdout if input was empty line. Fixes #26

### DIFF
--- a/repl/repl.py
+++ b/repl/repl.py
@@ -60,12 +60,14 @@ class Repl():
             # Timeout
             return ReplResult(prefix + "Execution timed out.", is_timeout=True)
         else:
+            # For multiline statements additional newline is needed. See #26 issue
+            start_index = 1 if len(input.strip()) else 0
             # Regular prompt - need to check for error
             result_str = "\n".join([
                 prefix + line
                 for line in fix_text(unicode(self.repl.before)).split("\n")
                 if len(line.strip())
-            ][1:])
+            ][start_index:])
             is_eof = self.prompt[index] == pexpect.EOF
             if is_eof:
                 result_str = "\n".join([result_str, prefix + " [exit]"])


### PR DESCRIPTION
For single line code REPL returns output instantly, but for multiline code additional line is needed, and return of this new line does not contains this empty line, so first line of result is useful data. Hence, we don't need to ignore this first line.
